### PR TITLE
전체 상품 조회 기능 리펙토링 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,11 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+
+    testImplementation 'org.mockito:mockito-core:3.3.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/onlinemarket/OnlineMarketApplication.java
+++ b/src/main/java/com/example/onlinemarket/OnlineMarketApplication.java
@@ -2,8 +2,10 @@ package com.example.onlinemarket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class OnlineMarketApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/onlinemarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/onlinemarket/domain/product/controller/ProductController.java
@@ -28,11 +28,13 @@ public class ProductController {
     private final ProductService productService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<ProductDTO>>> getAllProducts() {
+    public ResponseEntity<ApiResponse<List<ProductDTO>>> getAllProducts(
+        @RequestParam Long categoryId,
+        @RequestParam(defaultValue = "1") int page,
+        @RequestParam(defaultValue = "100") int limit) {
 
-        List<ProductDTO> products = productService.getAllProducts();
-
-        return ResponseEntity.ok(new ApiResponse<>(true, "All products retrieved", products));
+        List<ProductDTO> products = productService.getAllProducts(categoryId, page, limit);
+        return ResponseEntity.ok(new ApiResponse<>(true, "All products retrieved for category " + categoryId, products));
     }
 
 

--- a/src/main/java/com/example/onlinemarket/domain/product/dto/ProductDTO.java
+++ b/src/main/java/com/example/onlinemarket/domain/product/dto/ProductDTO.java
@@ -16,7 +16,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ProductDTO {
 
-    private long id;
+    private Long id;
+
+    private long categoryId;
+
+    private String categoryName; // 카테고리 이름 추가
 
     @NotNull
     @NotEmpty

--- a/src/main/java/com/example/onlinemarket/domain/product/mapper/ProductMapper.java
+++ b/src/main/java/com/example/onlinemarket/domain/product/mapper/ProductMapper.java
@@ -8,7 +8,7 @@ import org.apache.ibatis.annotations.Param;
 @Mapper
 public interface ProductMapper {
 
-    List<ProductDTO> findAll();
+    List<ProductDTO> findAll(Long categoryId, int offset, int limit);
 
     ProductDTO findById(long productId);
 

--- a/src/main/java/com/example/onlinemarket/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/onlinemarket/domain/product/service/ProductService.java
@@ -5,6 +5,7 @@ import com.example.onlinemarket.domain.product.dto.ProductDTO;
 import com.example.onlinemarket.domain.product.mapper.ProductMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,6 +14,7 @@ public class ProductService {
 
     private final ProductMapper productMapper;
 
+    @Cacheable(value = "products", key = "#categoryId")
     public List<ProductDTO> getAllProducts(Long categoryId, int page, int limit) {
         int offset = (page - 1) * limit;
         return productMapper.findAll(categoryId, offset, limit);

--- a/src/main/java/com/example/onlinemarket/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/onlinemarket/domain/product/service/ProductService.java
@@ -13,8 +13,9 @@ public class ProductService {
 
     private final ProductMapper productMapper;
 
-    public List<ProductDTO> getAllProducts() {
-        return productMapper.findAll();
+    public List<ProductDTO> getAllProducts(Long categoryId, int page, int limit) {
+        int offset = (page - 1) * limit;
+        return productMapper.findAll(categoryId, offset, limit);
     }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.datasource.jdbc-url=jdbc:mysql://localhost:3306/market
 spring.datasource.username=root
 spring.datasource.password=1234
 mybatis.mapper-locations=classpath:mapper/**/*.xml
+spring.cache.type=caffeine
+spring.cache.caffeine.spec=expireAfterWrite=10m,maximumSize=500

--- a/src/main/resources/mapper/ProductMapper.xml
+++ b/src/main/resources/mapper/ProductMapper.xml
@@ -5,8 +5,12 @@
 <mapper namespace="com.example.onlinemarket.domain.product.mapper.ProductMapper">
 
   <select id="findAll" resultType="com.example.onlinemarket.domain.product.dto.ProductDTO">
-    SELECT id, name, price
-    FROM Product
+    SELECT p.name, p.price, p.quantity, c.name
+    FROM Product p
+           INNER JOIN Category c ON p.categoryId = c.id
+    WHERE p.categoryId = #{categoryId}
+    ORDER BY p.id
+    LIMIT #{limit} OFFSET #{offset}
   </select>
 
   <select id="findById" resultType="com.example.onlinemarket.domain.product.dto.ProductDTO">

--- a/src/test/java/com/example/onlinemarket/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/example/onlinemarket/product/controller/ProductControllerTest.java
@@ -50,75 +50,85 @@ public class ProductControllerTest {
 
     @BeforeEach
     public void setUp() {
-        productDTO = ProductDTO.builder()
-                .id(1)
-                .name("geonhui")
-                .price(1000.0)
-                .description("Description")
-                .build();
+        productDTO = new ProductDTO(1L, 1L, "categoryName", "Product Name", 100.0, 40, "Test Description");
     }
 
     @Test
     @DisplayName("모든 상품 조회 성공 시 200 Ok를 반환")
-    public void testGetAllProducts() throws Exception {
+    public void testGetAllProductsSuccess() throws Exception {
+        Long categoryId = 1L;
+        int page = 1;
+        int size = 10;
         List<ProductDTO> allProducts = Arrays.asList(productDTO);
 
-        when(productService.getAllProducts()).thenReturn(allProducts);
+        when(productService.getAllProducts(categoryId, page, size)).thenReturn(allProducts);
 
         mockMvc.perform(get("/products")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data", hasSize(1)))
-                .andExpect(jsonPath("$.data[0].name", is(productDTO.getName())));
+                .param("categoryId", String.valueOf(categoryId))
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data['TestCategory']", hasSize(1)))
+            .andExpect(jsonPath("$.data['TestCategory'][0].name", is(productDTO.getName())));
     }
+
 
     @Test
     @DisplayName("상품 이름으로 검색 성공 시 200 Ok 반환")
     public void testSearchProductsByNameSuccess() throws Exception {
         when(productService.searchProductsByName("Test")).thenReturn(
-                Collections.singletonList(productDTO));
+            Collections.singletonList(productDTO));
 
         mockMvc.perform(get("/products/search")
-                        .param("productName", "Test")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data", hasSize(1)))
-                .andExpect(jsonPath("$.data[0].name", is(productDTO.getName())));
+                .param("productName", "Test")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data", hasSize(1)))
+            .andExpect(jsonPath("$.data[0].name", is(productDTO.getName())));
     }
 
     @Test
     @DisplayName("상품 이름으로 검색 실패 시 404 Not Found 반환 - 결과 없음")
     public void testSearchProductsByNameFailure() throws Exception {
         when(productService.searchProductsByName("nonexistent")).thenThrow(
-                new NotFoundException("No products found"));
+            new NotFoundException("No products found"));
 
         mockMvc.perform(get("/products/search")
-                        .param("productName", "nonexistent")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
+                .param("productName", "nonexistent")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("모든 상품 조회 실패 시 404 Not Found 반환")
     public void testGetAllProductsNotFound() throws Exception {
-        when(productService.getAllProducts()).thenThrow(
-                new NotFoundException("Products not found"));
+        Long categoryId = 1L;
+        int page = 1;
+        int size = 10;
+
+        when(productService.getAllProducts(categoryId, page, size)).thenThrow(
+            new NotFoundException("Products not found"));
 
         mockMvc.perform(get("/products")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
+                .param("categoryId", String.valueOf(categoryId))
+                .param("page", String.valueOf(page))
+                .param("size", String.valueOf(size))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
     }
+
 
     @Test
     @DisplayName("상품 ID로 특정 상품 조회 시 200 Ok 반환")
     public void testGetProductById() throws Exception {
-        when(productService.getProductById(1)).thenReturn(productDTO);
+        when(productService.getProductById(1L)).thenReturn(productDTO);
 
-        mockMvc.perform(get("/products/{id}", 1)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id", is(productDTO.getId())))
-                .andExpect(jsonPath("$.data.name", is(productDTO.getName())));
+        mockMvc.perform(get("/products/{id}", 1L)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.id", is(1))) // 수정됨
+            .andExpect(jsonPath("$.data.name", is(productDTO.getName())));
     }
 
 
@@ -126,78 +136,79 @@ public class ProductControllerTest {
     @DisplayName("상품 ID로 특정 상품 조회 실패시 404 Not Found 상태 코드 반환")
     public void testFailGetProductById() throws Exception {
         when(productService.getProductById(1)).thenThrow(
-                new NotFoundException("Product not found"));
+            new NotFoundException("Product not found"));
 
         mockMvc.perform(get("/products/{id}", 1)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
     }
 
     @Test
     @DisplayName("상품 추가 성공 시 201 Created 상태 코드 반환")
     public void testCreateProduct() throws Exception {
-
-        when(productService.createProduct(any())).thenReturn(productDTO.getId());
+        when(productService.createProduct(refEq(productDTO))).thenReturn(productDTO.getId());
 
         mockMvc.perform(post("/products")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(productDTO)))
-                .andExpect(status().isCreated());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(productDTO)))
+            .andExpect(status().isCreated());
 
         Mockito.verify(productService).createProduct(refEq(productDTO));
     }
+
 
     @Test
     @DisplayName("상품 추가 실패 시 400 Bad Request 상태 코드 반환")
     public void testFailCreateProduct() throws Exception {
         Mockito.doThrow(new ValidationException()).when(productService)
-                .createProduct(refEq(productDTO));
+            .createProduct(refEq(productDTO));
 
         mockMvc.perform(post("/products")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(productDTO)))
-                .andExpect(status().isBadRequest());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(productDTO)))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("상품 정보 업데이트 성공 시 200 OK 상태 코드 반환")
     public void testUpdateProduct() throws Exception {
-        when(productService.updateProduct(any())).thenReturn(productDTO);
+        when(productService.updateProduct(refEq(productDTO))).thenReturn(productDTO);
 
         mockMvc.perform(put("/products/{id}", productDTO.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(productDTO)))
-                .andExpect(status().isOk());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(productDTO)))
+            .andExpect(status().isOk());
     }
+
 
     @Test
     @DisplayName("상품 정보 업데이트 실패 시 400 Bad Request 상태 코드 반환")
     public void testFailUpdateProduct() throws Exception {
         when(productService.updateProduct(any())).thenThrow(
-                new ValidationException("Invalid data"));
+            new ValidationException("Invalid data"));
 
         mockMvc.perform(put("/products/{id}", productDTO.getId())
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(productDTO)))
-                .andExpect(status().isBadRequest());
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(productDTO)))
+            .andExpect(status().isBadRequest());
     }
 
     @Test
     @DisplayName("상품 정보 삭제 시 200 OK 상태 코드를 반환한다.")
     public void testDeleteProduct() throws Exception {
         mockMvc.perform(delete("/products/{id}", 1)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
     }
 
     @Test
     @DisplayName("상품 정보 삭제 성공 시 404 Not Found 상태 코드 반환")
     public void testFailDeleteProduct() throws Exception {
         Mockito.doThrow(new NotFoundException("Product not found")).when(productService)
-                .deleteProduct(1);
+            .deleteProduct(1);
 
         mockMvc.perform(delete("/products/{id}", 1)
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/example/onlinemarket/product/dto/ProductDTOTest.java
+++ b/src/test/java/com/example/onlinemarket/product/dto/ProductDTOTest.java
@@ -24,7 +24,7 @@ public class ProductDTOTest {
     @Test
     @DisplayName("유효한 ProductDTO 생성")
     public void whenValidProduct_thenNoConstraintViolations() {
-        ProductDTO product = new ProductDTO(1L, "Valid Product", 1000.0, 40, "Valid Description");
+        ProductDTO product = new ProductDTO(1L, 1L, "category Name", "Valid Product", 1000.0, 40, "Valid Description");
 
         Set<ConstraintViolation<ProductDTO>> violations = validator.validate(product);
 
@@ -34,7 +34,7 @@ public class ProductDTOTest {
     @Test
     @DisplayName("유효하지 않은 이름 - Null")
     public void whenNullName_thenOneConstraintViolation() {
-        ProductDTO product = new ProductDTO(1, null, 1000.0, 40, "Valid Description");
+        ProductDTO product = new ProductDTO(1L, 1L, "CategoryName", null, 1000.0, 40, "Valid Description");
 
         Set<ConstraintViolation<ProductDTO>> violations = validator.validate(product);
 
@@ -44,7 +44,7 @@ public class ProductDTOTest {
     @Test
     @DisplayName("유효하지 않은 가격 - 음수")
     public void whenNegativePrice_thenConstraintViolation() {
-        ProductDTO product = new ProductDTO(1, "Product", -10.0, 40, "Valid Description");
+        ProductDTO product = new ProductDTO(1L, 1L, "Category Name", "Product", -10.0, 40, "Valid Description");
 
         Set<ConstraintViolation<ProductDTO>> violations = validator.validate(product);
 
@@ -54,7 +54,7 @@ public class ProductDTOTest {
     @Test
     @DisplayName("유효하지 않은 설명 - 너무 짧음")
     public void whenShortDescription_thenConstraintViolation() {
-        ProductDTO product = new ProductDTO(1, "Product", 1000.0, 40, "Short");
+        ProductDTO product = new ProductDTO(1L, 1L, "Category Name", "Product", 1000.0, 40, "Short");
 
         Set<ConstraintViolation<ProductDTO>> violations = validator.validate(product);
 
@@ -65,7 +65,7 @@ public class ProductDTOTest {
     @DisplayName("유효하지 않은 설명 - 너무 길음")
     public void whenLongDescription_thenConstraintViolation() {
         String longDescription = "This is a very long description".repeat(10);
-        ProductDTO product = new ProductDTO(1, "Product", 1000.0, 40, longDescription);
+        ProductDTO product = new ProductDTO(1L, 1L, "Category Name", "Product", 1000.0, 40, longDescription);
 
         Set<ConstraintViolation<ProductDTO>> violations = validator.validate(product);
 

--- a/src/test/java/com/example/onlinemarket/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/onlinemarket/product/service/ProductServiceTest.java
@@ -7,7 +7,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import com.example.onlinemarket.common.exception.NotFoundException;
 import com.example.onlinemarket.domain.category.dto.CategoryDTO;
@@ -15,6 +17,7 @@ import com.example.onlinemarket.domain.category.mapper.CategoryMapper;
 import com.example.onlinemarket.domain.product.dto.ProductDTO;
 import com.example.onlinemarket.domain.product.mapper.ProductMapper;
 import com.example.onlinemarket.domain.product.service.ProductService;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,18 +47,31 @@ public class ProductServiceTest {
     }
 
     @Test
-    @DisplayName("모든 상품 조회 성공")
+    @DisplayName("상품 조회 성공 시 반환된 상품 목록 검증")
     public void testGetAllProductsSuccess() {
+        // Arrange
         Long categoryId = 1L;
         int page = 1;
-        int size = 10;
+        int limit = 100;
+        ProductDTO productDTO2 = ProductDTO.builder()
+            .id(1L)
+            .categoryId(categoryId)
+            .name("Product Name")
+            .price(100.0)
+            .quantity(10)
+            .description("Product Description")
+            .build();
 
-        //        when(productMapper.findAll(anyInt(), anyInt())).thenReturn(Collections.singletonList(productDTO));
-        when(categoryMapper.findById(anyLong())).thenReturn(new CategoryDTO(categoryId, "TestCategory"));
+        List<ProductDTO> expectedProducts = Arrays.asList(productDTO2);
 
-        List<ProductDTO> products = productService.getAllProducts(categoryId, page, size);
+        when(productMapper.findAll(categoryId, 0, limit)).thenReturn(expectedProducts);
 
-        assertFalse(products.isEmpty());
+        // Act
+        List<ProductDTO> actualProducts = productService.getAllProducts(categoryId, page, limit);
+
+        // Assert
+        assertEquals(expectedProducts, actualProducts);
+        verify(productMapper, times(1)).findAll(categoryId, 0, limit);
     }
 
 

--- a/src/test/java/com/example/onlinemarket/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/onlinemarket/product/service/ProductServiceTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.example.onlinemarket.common.exception.NotFoundException;
+import com.example.onlinemarket.domain.category.dto.CategoryDTO;
+import com.example.onlinemarket.domain.category.mapper.CategoryMapper;
 import com.example.onlinemarket.domain.product.dto.ProductDTO;
 import com.example.onlinemarket.domain.product.mapper.ProductMapper;
 import com.example.onlinemarket.domain.product.service.ProductService;
@@ -32,22 +35,29 @@ public class ProductServiceTest {
     private ProductService productService;
 
     private ProductDTO productDTO;
+    private CategoryMapper categoryMapper;
 
     @BeforeEach
     public void setUp() {
-        productDTO = new ProductDTO(1L, "Test Product", 1000.0, 40, "Test Description");
+        productDTO = new ProductDTO(1L, 1l, "categoryName", "Product Name", 100.0, 40, "Test Description");
+        when(categoryMapper.findById(anyLong())).thenReturn(new CategoryDTO(1L, "TestCategory"));
     }
 
     @Test
     @DisplayName("모든 상품 조회 성공")
     public void testGetAllProductsSuccess() {
-        when(productMapper.findAll()).thenReturn(Collections.singletonList(productDTO));
+        Long categoryId = 1L;
+        int page = 1;
+        int size = 10;
 
-        List<ProductDTO> products = productService.getAllProducts();
+        //        when(productMapper.findAll(anyInt(), anyInt())).thenReturn(Collections.singletonList(productDTO));
+        when(categoryMapper.findById(anyLong())).thenReturn(new CategoryDTO(categoryId, "TestCategory"));
+
+        List<ProductDTO> products = productService.getAllProducts(categoryId, page, size);
 
         assertFalse(products.isEmpty());
-        assertEquals(productDTO, products.get(0));
     }
+
 
     @Test
     @DisplayName("상품 이름으로 검색 성공")


### PR DESCRIPTION
기존의 작성했던 전체 상품 조회 코드에 대한 성능테스트를 진행했지만 평균 응답 시간 1550ms로 성능이 매우 떨어지는 결과가 나와서 리펙토링을 진행 하였습니다.

- 1차 리펙토링 : 기존 코드 + 페이징 기법 적용
- 2차 리펙토링 : 기존 코드 + 페이징 기법 + 캐싱 적용

2차 리펙토링까지 마친 후 다시 성능  테스트 진행한 결과로 평균 응답 시간 : 330ms로 성능이 개선되었음을 확인 했습니다.