### PR TITLE
전체 상품 목록 조회 - Redis를 통한 캐싱 적용 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/onlinemarket/common/Redis/RedisService.java
+++ b/src/main/java/com/example/onlinemarket/common/Redis/RedisService.java
@@ -1,0 +1,54 @@
+package com.example.onlinemarket.common.Redis;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValues(String key, Object data, long timeout, TimeUnit unit) {
+        redisTemplate.opsForValue().set(key, data, timeout, unit);
+    }
+
+    public Object getValues(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValues(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/src/main/java/com/example/onlinemarket/common/config/RedisConfig.java
+++ b/src/main/java/com/example/onlinemarket/common/config/RedisConfig.java
@@ -1,0 +1,36 @@
+package com.example.onlinemarket.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.datasource.jdbc-url=jdbc:mysql://localhost:3306/market
 spring.datasource.username=root
 spring.datasource.password=1234
 mybatis.mapper-locations=classpath:mapper/**/*.xml
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.cache.type=redis

--- a/src/test/java/com/example/onlinemarket/Redis/RedisTemplateTest.java
+++ b/src/test/java/com/example/onlinemarket/Redis/RedisTemplateTest.java
@@ -1,0 +1,95 @@
+package com.example.onlinemarket.Redis;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+
+@SpringBootTest
+public class RedisTemplateTest {
+
+    @Autowired
+    RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    public void opsForValue() throws Exception {
+        //given
+        ValueOperations<String, Object> valueOperations = redisTemplate.opsForValue();
+        String key = "stringKey";
+        String value = "stringValue";
+
+        valueOperations.set(key, value);
+
+        //when
+        String result = (String) valueOperations.get(key);
+
+        //then
+        Assertions.assertThat(result).isEqualTo(value);
+    }
+
+    @Test
+    public void opsForList() throws Exception {
+        //given
+        ListOperations<String, Object> listOperations = redisTemplate.opsForList();
+        String listKey = "listKey";
+
+        List<Long> list = List.of(1L, 2L, 3L, 4L, 5L);
+
+        //when
+        for (Long l : list) {
+            listOperations.leftPush(listKey, l);
+        }
+
+        //then
+        for (Long l : list) {
+            Long result = (Long) listOperations.rightPop(listKey);
+            Assertions.assertThat(result).isEqualTo(l);
+        }
+    }
+
+    @Test
+    public void opsForSet() throws Exception {
+        //given
+        SetOperations<String, Object> setOperations = redisTemplate.opsForSet();
+        String setKey = "setKey";
+
+        //when
+        setOperations.add(setKey, "h", "e", "l", "l", "o");
+        Set<String> result = setOperations.members(setKey).stream().map(it -> (String) it).collect(Collectors.toSet());
+
+        //then
+        Assertions.assertThat(result).containsOnly("h", "e", "l", "o");
+    }
+
+    @Test
+    public void opsForHash() {
+        //given
+        HashOperations<String, Object, Object> hashOperations = redisTemplate.opsForHash();
+        String key = "hashKey";
+
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("key3", "value3");
+
+        hashOperations.putAll(key, map);
+
+        //when
+        Map<Object, Object> resultMap = hashOperations.entries(key);
+        String resultValue = (String) hashOperations.get(key, "key1");
+
+        //then
+        Assertions.assertThat(resultMap).containsAllEntriesOf(map);
+        Assertions.assertThat(resultValue).isEqualTo("value1");
+    }
+}


### PR DESCRIPTION
### 캐싱 키 설계
- 각 상품 목록 조회 요청에 대해 고유한 캐싱 키를 생성
- 카테고리 ID와 페이지 번호를 포함하여, "category:[categoryId]:page:[page]:products"의 형태로 구성되어 각 페이지에 대한 상품 목록을 식별할 수 있도록 설정하였습니다.

### ProductService 내에서 캐싱 로직을 구현
1. 사용자가 특정 카테고리의 상품 목록 페이지를 요청할 때, 먼저 Redis에서 해당 캐싱 키를 조회
2. 캐시에 데이터가 존재하면, 캐시된 데이터를 반환합니다. 
3. 캐시에 데이터가 없는 경우에만 데이터베이스에서 상품 목록을 조회하고, 조회된 데이터를 Redis에 캐싱한 후 사용자에게 반환

### 캐싱 데이터 만료 설정
- 캐시 항목에 대한 만료 시간을 설정하여 만료 시간이 지나면 자동으로 캐시가 삭제되어 데이터의 일관성을 유지의 목적을 두었습니다.

### RedisService 클래스 생성
- RedisService를 별도로 생성하여 캐싱 로직을 분리함으로써, Redis를 사용하는 캐싱 로직을 다른 서비스나 컴포넌트에서도 쉽게 재사용 할 수 있도록 설계하였습니다.
- Redis에 데이터를 저장하고 조회하는 기본적인 메서드들(setValues, getValues, deleteValues 등)을 작성하였습니다.